### PR TITLE
Update GTK platform from EOL’d 3.30 to 3.32

### DIFF
--- a/nl.hjdskes.gcolor3.json
+++ b/nl.hjdskes.gcolor3.json
@@ -1,7 +1,7 @@
 {
     "app-id": "nl.hjdskes.gcolor3",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.30",
+    "runtime-version": "3.34",
     "sdk": "org.gnome.Sdk",
     "command": "gcolor3",
     "finish-args": [

--- a/nl.hjdskes.gcolor3.json
+++ b/nl.hjdskes.gcolor3.json
@@ -1,7 +1,7 @@
 {
     "app-id": "nl.hjdskes.gcolor3",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.34",
+    "runtime-version": "3.32",
     "sdk": "org.gnome.Sdk",
     "command": "gcolor3",
     "finish-args": [


### PR DESCRIPTION
Setting GTK to v3.34 shows errors due to `G_PARAM_PRIVATE` being deprecated. Have no time to look further into this.

GTK 3.32 however is enough for getting rid of the annoying warnings that GTK 3.30 is EOL, which I see at about every `flatpak update` action.