### PR TITLE
--socket=fallback-x11, FEDC support

### DIFF
--- a/nl.hjdskes.gcolor3.json
+++ b/nl.hjdskes.gcolor3.json
@@ -24,7 +24,13 @@
                 {
                     "type": "git",
                     "url": "https://github.com/flatpak/libportal.git",
-                    "commit": "bff3289781ef27388e75f772d5fe9dee20fdfb53"
+                    "commit": "bff3289781ef27388e75f772d5fe9dee20fdfb53",
+                    "tag": "0.4",
+                     "commit": "f68764e288ede516d902b131cc4fadded3804059",
+                     "x-checker-data": {
+                         "type": "git",
+                         "tag-pattern": "^([\\d.]+)$"
+                     }
                 }
             ]
         },
@@ -35,7 +41,12 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/World/gcolor3.git",
-                    "tag": "v2.4.0"
+                    "tag": "v2.4.0",
+                     "commit": "7053f9e6a890175fc212df625e02ffbdce418146",
+                     "x-checker-data": {
+                         "type": "git",
+                         "tag-pattern": "^v([\\d.]+)$"
+                     }
                 }
             ]
         }

--- a/nl.hjdskes.gcolor3.json
+++ b/nl.hjdskes.gcolor3.json
@@ -6,7 +6,7 @@
     "command": "gcolor3",
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--metadata=X-DConf=migrate-path=/nl/hjdskes/gcolor3/"
     ],


### PR DESCRIPTION
Used --socket=fallback-x11 instead of --socket=x11, added FEDC support.