### PR TITLE
Switch to freedesktop.org runtime.

### DIFF
--- a/nl.hjdskes.gcolor3.json
+++ b/nl.hjdskes.gcolor3.json
@@ -1,8 +1,8 @@
 {
     "app-id": "nl.hjdskes.gcolor3",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
-    "sdk": "org.gnome.Sdk",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "21.08",
+    "sdk": "org.freedesktop.Sdk",
     "command": "gcolor3",
     "finish-args": [
         "--share=ipc",


### PR DESCRIPTION
The app isn't really using any GNOME-specific dependencies or GNOME-specific HIG, and builds and runs on FD.O just fine without any change in functionality.