### PR TITLE
Bump runtime to 45

### DIFF
--- a/nl.hjdskes.gcolor3.json
+++ b/nl.hjdskes.gcolor3.json
@@ -1,7 +1,7 @@
 {
     "app-id": "nl.hjdskes.gcolor3",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "gcolor3",
     "finish-args": [


### PR DESCRIPTION
Since 43 is going EOL soon it might be good to bump the runtime version up to 45