### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/nl.hjdskes.gcolor3.json
+++ b/nl.hjdskes.gcolor3.json
@@ -1,7 +1,7 @@
 {
     "app-id": "nl.hjdskes.gcolor3",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "command": "gcolor3",
     "finish-args": [


### PR DESCRIPTION
GNOME runtime version 46 will reach EOL on 2025-03-15.

Source: https://release.gnome.org/calendar/